### PR TITLE
Update draftail integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ Currently there are two available modes:
   - ```wagtailreadinglevelcoleman``` for Coleman-Liau Index
   - ```wagtailreadinglevelflesch``` for Flesh Reading Ease Score
   - ```wagtailreadinglevelfog``` for the Gunning Fog index
+- The plugin will show automatically for any rich text fields which don't use a limited ```features``` list. For feature-limited fields, you'll need to add their names to that list. The names are:
+  - ```readinglevel``` for Automated Readability Index (Reading Age)
+  - ```readinglevelsmog``` for SMOG Index
+  - ```readinglevelcoleman``` for Coleman-Liau Index
+  - ```readinglevelflesch``` for Flesch Reading Ease Score
+  - ```readinglevelfog``` for the Gunning Fog index
 
 ## Usage
 Once installed You will see the reading level and/or smog index displayed in the toolbar of all rich text fields in your Wagtail admin area (depending on which you added to your list of installed apps).

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,12 @@ Installation
   - ```wagtailreadinglevelcoleman``` for Coleman-Liau Index
   - ```wagtailreadinglevelflesch``` for Flesh Reading Ease Score
   - ```wagtailreadinglevelfog``` for the Gunning Fog index
+- The plugin will show automatically for any rich text fields which don't use a limited ```features``` list. For feature-limited fields, you'll need to add their names to that list. The names are:
+  - ```readinglevel``` for Automated Readability Index (Reading Age)
+  - ```readinglevelsmog``` for SMOG Index
+  - ```readinglevelcoleman``` for Coleman-Liau Index
+  - ```readinglevelflesch``` for Flesch Reading Ease Score
+  - ```readinglevelfog``` for the Gunning Fog index
 
 Usage
 -----

--- a/wagtailreadinglevel/wagtail_hooks.py
+++ b/wagtailreadinglevel/wagtail_hooks.py
@@ -4,24 +4,25 @@ On loading, Wagtail will find this file and execute the contents.
 """
 from __future__ import unicode_literals
 
-# Django imports
-from django.conf import settings
-from django.utils.html import format_html, format_html_join
-
 # Wagtail core imports
+from wagtail.admin.rich_text.editors.draftail import features as draftail_features
 from wagtail.core import hooks
 
 
-@hooks.register('insert_editor_js')
-def editor_js():
-    """ Adds additional JavaScript files or code snippets to the page editor. """
-    # js_files = ['hallo-readinglevel-plugin.js','draftail-readinglevel-plugin.js']
-    js_files = ['wagtailadmin/js/draftail.js','api-monkeypatch.js','wagtailreadinglevel.bundle.js']
-    js_includes = format_html_join('\n', '<script src="{0}{1}"></script>',
-        ((settings.STATIC_URL, filename) for filename in js_files)
+@hooks.register('register_rich_text_features')
+def register_readinglevel_feature(features):
+    feature_name = 'readinglevel'
+    type_ = feature_name.upper()
+    control = {
+        'type': type_,
+        'description': 'Reading level',
+    }
+    features.register_editor_plugin(
+        'draftail',
+        feature_name,
+        draftail_features.EntityFeature(
+            control,
+            js=['api-monkeypatch.js', 'wagtailreadinglevel.bundle.js']
+        )
     )
-    return js_includes + format_html(
-        """
-        <script></script>
-        """
-    )
+    features.default_features.append(feature_name)

--- a/wagtailreadinglevelcoleman/wagtail_hooks.py
+++ b/wagtailreadinglevelcoleman/wagtail_hooks.py
@@ -4,23 +4,25 @@ On loading, Wagtail will find this file and execute the contents.
 """
 from __future__ import unicode_literals
 
-# Django imports
-from django.conf import settings
-from django.utils.html import format_html, format_html_join
-
 # Wagtail core imports
+from wagtail.admin.rich_text.editors.draftail import features as draftail_features
 from wagtail.core import hooks
 
 
-@hooks.register('insert_editor_js')
-def editor_js():
-    """ Adds additional JavaScript files or code snippets to the page editor. """
-    js_files = ['wagtailadmin/js/draftail.js','api-monkeypatch.js','wagtailreadinglevel.coleman.bundle.js']
-    js_includes = format_html_join('\n', '<script src="{0}{1}"></script>',
-        ((settings.STATIC_URL, filename) for filename in js_files)
+@hooks.register('register_rich_text_features')
+def register_readinglevel_feature(features):
+    feature_name = 'readinglevelcoleman'
+    type_ = feature_name.upper()
+    control = {
+        'type': type_,
+        'description': 'Reading level - Coleman-Liau',
+    }
+    features.register_editor_plugin(
+        'draftail',
+        feature_name,
+        draftail_features.EntityFeature(
+            control,
+            js=['api-monkeypatch.js', 'wagtailreadinglevel.coleman.bundle.js']
+        )
     )
-    return js_includes + format_html(
-        """
-        <script></script>
-        """
-    )
+    features.default_features.append(feature_name)

--- a/wagtailreadinglevelflesch/wagtail_hooks.py
+++ b/wagtailreadinglevelflesch/wagtail_hooks.py
@@ -4,23 +4,25 @@ On loading, Wagtail will find this file and execute the contents.
 """
 from __future__ import unicode_literals
 
-# Django imports
-from django.conf import settings
-from django.utils.html import format_html, format_html_join
-
 # Wagtail core imports
+from wagtail.admin.rich_text.editors.draftail import features as draftail_features
 from wagtail.core import hooks
 
 
-@hooks.register('insert_editor_js')
-def editor_js():
-    """ Adds additional JavaScript files or code snippets to the page editor. """
-    js_files = ['wagtailadmin/js/draftail.js','api-monkeypatch.js','wagtailreadinglevel.flesch.bundle.js']
-    js_includes = format_html_join('\n', '<script src="{0}{1}"></script>',
-        ((settings.STATIC_URL, filename) for filename in js_files)
+@hooks.register('register_rich_text_features')
+def register_readinglevel_feature(features):
+    feature_name = 'readinglevelflesch'
+    type_ = feature_name.upper()
+    control = {
+        'type': type_,
+        'description': 'Reading level - Flesch',
+    }
+    features.register_editor_plugin(
+        'draftail',
+        feature_name,
+        draftail_features.EntityFeature(
+            control,
+            js=['api-monkeypatch.js', 'wagtailreadinglevel.flesch.bundle.js']
+        )
     )
-    return js_includes + format_html(
-        """
-        <script></script>
-        """
-    )
+    features.default_features.append(feature_name)

--- a/wagtailreadinglevelfog/wagtail_hooks.py
+++ b/wagtailreadinglevelfog/wagtail_hooks.py
@@ -4,23 +4,25 @@ On loading, Wagtail will find this file and execute the contents.
 """
 from __future__ import unicode_literals
 
-# Django imports
-from django.conf import settings
-from django.utils.html import format_html, format_html_join
-
 # Wagtail core imports
+from wagtail.admin.rich_text.editors.draftail import features as draftail_features
 from wagtail.core import hooks
 
 
-@hooks.register('insert_editor_js')
-def editor_js():
-    """ Adds additional JavaScript files or code snippets to the page editor. """
-    js_files = ['wagtailadmin/js/draftail.js','api-monkeypatch.js','wagtailreadinglevel.fog.bundle.js']
-    js_includes = format_html_join('\n', '<script src="{0}{1}"></script>',
-        ((settings.STATIC_URL, filename) for filename in js_files)
+@hooks.register('register_rich_text_features')
+def register_readinglevel_feature(features):
+    feature_name = 'readinglevelfog'
+    type_ = feature_name.upper()
+    control = {
+        'type': type_,
+        'description': 'Reading level - Gunning Fog',
+    }
+    features.register_editor_plugin(
+        'draftail',
+        feature_name,
+        draftail_features.EntityFeature(
+            control,
+            js=['api-monkeypatch.js', 'wagtailreadinglevel.fog.bundle.js']
+        )
     )
-    return js_includes + format_html(
-        """
-        <script></script>
-        """
-    )
+    features.default_features.append(feature_name)

--- a/wagtailreadinglevelsmog/wagtail_hooks.py
+++ b/wagtailreadinglevelsmog/wagtail_hooks.py
@@ -4,23 +4,25 @@ On loading, Wagtail will find this file and execute the contents.
 """
 from __future__ import unicode_literals
 
-# Django imports
-from django.conf import settings
-from django.utils.html import format_html, format_html_join
-
 # Wagtail core imports
+from wagtail.admin.rich_text.editors.draftail import features as draftail_features
 from wagtail.core import hooks
 
 
-@hooks.register('insert_editor_js')
-def editor_js():
-    """ Adds additional JavaScript files or code snippets to the page editor. """
-    js_files = ['wagtailadmin/js/draftail.js','api-monkeypatch.js','wagtailreadinglevel.smog.bundle.js']
-    js_includes = format_html_join('\n', '<script src="{0}{1}"></script>',
-        ((settings.STATIC_URL, filename) for filename in js_files)
+@hooks.register('register_rich_text_features')
+def register_readinglevel_feature(features):
+    feature_name = 'readinglevelsmog'
+    type_ = feature_name.upper()
+    control = {
+        'type': type_,
+        'description': 'Reading level - SMOG',
+    }
+    features.register_editor_plugin(
+        'draftail',
+        feature_name,
+        draftail_features.EntityFeature(
+            control,
+            js=['api-monkeypatch.js', 'wagtailreadinglevel.smog.bundle.js']
+        )
     )
-    return js_includes + format_html(
-        """
-        <script></script>
-        """
-    )
+    features.default_features.append(feature_name)


### PR DESCRIPTION
For https://github.com/vixdigital/wagtail-readinglevel/issues/28

Similar to the note on https://github.com/wagtail/wagtail/issues/6724#issuecomment-779383334, the issue here is the insertion of the JS files using the `insert_editor_js` hook, which won't work with Draftail in the previous way from Wagtail >= 2.11. I've changed this so that the files are inserted in the `register_rich_text_features` hook instead.

(Note that using `insert_editor_js` _was_ the documented approach for including extra JS files up to [Wagtail 2.1](https://docs.wagtail.io/en/v2.1/advanced_topics/customisation/extending_draftail.html#creating-new-entities), but this changed from the [2.2 docs](https://docs.wagtail.io/en/v2.2/advanced_topics/customisation/extending_draftail.html#creating-new-entities) onwards.)

It looks to me like a consequence of this change is that the features are no longer automatically pulled into all rich text fields: specifically, any fields which define a limited list of Draftail features will now need to explicitly include the required reading level feature(s). I've updated the README files to reflect this.

